### PR TITLE
feat(theory function): Improve the code related to the theory formulas, considering the case where the position of the first element is not at the origin.

### DIFF
--- a/test_cylinder.m
+++ b/test_cylinder.m
@@ -52,7 +52,7 @@ for m = 1:M-1
     [sc,F]=complex_cohere(z(1,:)',z(m+1,:)',NFFT,fs,hanning(NFFT),0.75*NFFT);
     sc_sim(m,:) = real(sc');
 
-    sc_theory(m,:) = besselj(0,w*d(m+1)/c);
+    sc_theory(m,:) = besselj(0,w*(d(m+1)-d(1))/c);
 end
 
 %% Plot results
@@ -65,7 +65,7 @@ plot(F/1000,sc_theory(m,:),'--k')
 hold off;
 xlabel('Frequency [kHz]');
 ylabel('Spatial Coherence');
-title(sprintf('Distance %1.2f m',d(m+1)));
+title(sprintf('Distance %1.2f m',d(m+1)-d(1)));
 set(gca,'DataAspectRatio',[1 0.75 1]);
 legend('Simulation','Theory');
 grid on;
@@ -79,7 +79,7 @@ plot(F/1000,sc_theory(m,:),'--k')
 hold off;
 xlabel('Frequency [kHz]');
 ylabel('Spatial Coherence');
-title(sprintf('Distance %1.2f m',d(m+1)));
+title(sprintf('Distance %1.2f m',d(m+1)-d(1)));
 set(gca,'DataAspectRatio',[1 0.75 1]);
 legend('Simulation','Theory');
 grid on;

--- a/test_sphere.m
+++ b/test_sphere.m
@@ -53,7 +53,7 @@ for m = 1:M-1
     [sc,F]=complex_cohere(z(1,:)',z(m+1,:)',NFFT,fs,hanning(NFFT),0.75*NFFT);
     sc_sim(m,:) = real(sc');
 
-    sc_theory(m,:) = sinc(w*d(m+1)/c/pi);
+    sc_theory(m,:) = sinc(w*(d(m+1)-d(1))/c/pi);
 end
 
 %% Plot results
@@ -66,7 +66,7 @@ plot(F/1000,sc_theory(m,:),'--k')
 hold off;
 xlabel('Frequency [kHz]');
 ylabel('Spatial Coherence');
-title(sprintf('Distance %1.2f m',d(m+1)));
+title(sprintf('Distance %1.2f m',d(m+1)-d(1)));
 set(gca,'DataAspectRatio',[1 0.75 1]);
 legend('Simulation','Theory');
 grid on;
@@ -80,7 +80,7 @@ plot(F/1000,sc_theory(m,:),'--k')
 hold off;
 xlabel('Frequency [kHz]');
 ylabel('Spatial Coherence');
-title(sprintf('Distance %1.2f m',d(m+1)));
+title(sprintf('Distance %1.2f m',d(m+1)-d(1)));
 set(gca,'DataAspectRatio',[1 0.75 1]);
 legend('Simulation','Theory');
 grid on;


### PR DESCRIPTION
Improve the code related to the theory formulas, considering the case where the position of the first element is not at the origin.

The purpose of doing this is to avoid the discrepancy between the theoretical value and the calculated value, when the user applies the code from the repository to their own code, due to the first element position not being at the origin.

I add the relative sensor distances to the code of theory formulas, just like you have done in sinf_*D.m and cinf_*D.m.

Thank you so much for providing the code!

Best regards,
Derek